### PR TITLE
✨ feat: add Tabs Content (breaking changes)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitepress';
+import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs'
 import { pagefindPlugin } from 'vitepress-plugin-pagefind'
 import { mainSidebar, scenesSidebar, arsenalSidebar, techniqueSidebar, prayerSidebar, resourcesSidebar, aboutSidebar } from './sidebar_config'
 
@@ -15,6 +16,11 @@ export default defineConfig({
   ],
   vite: {
     plugins: [pagefindPlugin()],
+  },
+  markdown: {
+    config(md) {
+      md.use(tabsMarkdownPlugin)
+    }
   },
   cleanUrls: true,
 

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,11 @@
+// .vitepress/theme/index.ts
+import type { Theme } from 'vitepress'
+import DefaultTheme from 'vitepress/theme'
+import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client'
+
+export default {
+  extends: DefaultTheme,
+  enhanceApp({ app }) {
+    enhanceAppWithTabs(app)
+  }
+} satisfies Theme

--- a/docs/resources/templates/copypaste.md
+++ b/docs/resources/templates/copypaste.md
@@ -41,7 +41,6 @@
 
 - Output
 
-```markdown
 |  Technique Name           |                           |
 |---------------------------|---------------------------|
 | **Speedrun Categories**   |                           |
@@ -50,7 +49,6 @@
 | **Setup Required**        |                           |
 | **Pixel/Frame related?**  |                           |
 | **Change Game Behavior?** |                           |
-```
 
 ## Callout
 

--- a/docs/resources/templates/copypaste.md
+++ b/docs/resources/templates/copypaste.md
@@ -4,6 +4,19 @@
 
 ### Scene Table
 
+- Input
+
+```markdown
+| **Scene id or name**                |                  |
+|-------------------------------------|------------------|
+| **No. of Exits**                    |                  |
+| [**Exits Position**](##exits)       |                  |
+| [**Enemies**](##enemies)            |                  |
+| [**Checks**](##checks)              |                  |
+```
+
+- Output
+
 | **Scene id or name**                |                  |
 |-------------------------------------|------------------|
 | **No. of Exits**                    |                  |
@@ -13,6 +26,9 @@
 
 ### Technique Table
 
+- Input
+
+```markdown
 |  Technique Name           |                           |
 |---------------------------|---------------------------|
 | **Speedrun Categories**   |                           |
@@ -21,10 +37,62 @@
 | **Setup Required**        |                           |
 | **Pixel/Frame related?**  |                           |
 | **Change Game Behavior?** |                           |
+```
+
+- Output
+
+```markdown
+|  Technique Name           |                           |
+|---------------------------|---------------------------|
+| **Speedrun Categories**   |                           |
+| **Game Version**          |                           |
+| **Requirements**          |                           |
+| **Setup Required**        |                           |
+| **Pixel/Frame related?**  |                           |
+| **Change Game Behavior?** |                           |
+```
 
 ## Callout
 
-```md
+:::tip
+You can modify the callout title by appending it to the end of the type.
+For example, `:::info Title` will have "Title" as its title.
+:::
+
+- Input
+
+```markdown
+::: info
+This is an info box.
+:::
+```
+
+```markdown
+::: tip
+This is a tip.
+:::
+```
+
+```markdown
+::: warning
+This is a warning.
+:::
+```
+
+```markdown
+::: danger
+This is a dangerous warning.
+:::
+```
+
+```markdown
+::: details
+This is a details block.
+:::
+```
+
+- Output
+
 ::: info
 This is an info box.
 :::
@@ -45,13 +113,6 @@ This is a dangerous warning.
 This is a details block.
 :::
 
-```
-
-:::tip
-You can modify the callout title by appending it to the end of the type.
-For example, `:::info Title` will have "Title" as its title.
-:::
-
 ## Video autoplay Tag
 
 ```html
@@ -59,3 +120,27 @@ For example, `:::info Title` will have "Title" as its title.
 
 </video>
 ```
+
+## Tabs Component
+
+Doc [here](https://vitepress-plugins.sapphi.red/tabs/#syntax)
+
+- Input
+
+```markdown
+:::tabs
+== tab a
+a content
+== tab b
+b content
+:::
+```
+
+- Output
+
+:::tabs
+== tab a
+a content
+== tab b
+b content
+:::

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "vitepress": "v1.0.0-rc.31",
+        "vitepress-plugin-tabs": "^0.5.0",
         "vue": "v3.3.8"
       }
     },
@@ -2463,6 +2464,16 @@
         "@vue/composition-api": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitepress-plugin-tabs": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/vitepress-plugin-tabs/-/vitepress-plugin-tabs-0.5.0.tgz",
+      "integrity": "sha512-SIhFWwGsUkTByfc2b279ray/E0Jt8vDTsM1LiHxmCOBAEMmvzIBZSuYYT1DpdDTiS3SuJieBheJkYnwCq/yD9A==",
+      "dev": true,
+      "peerDependencies": {
+        "vitepress": "^1.0.0-rc.27",
+        "vue": "^3.3.8"
       }
     },
     "node_modules/vue": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "devDependencies": {
     "vitepress": "v1.0.0-rc.31",
+    "vitepress-plugin-tabs": "^0.5.0",
     "vue": "v3.3.8"
   },
   "scripts": {


### PR DESCRIPTION
Adds a plugin to handle Tabs Content. It works similarly to Vitepress "code blocks", but allows to display any Vue component inside each tab, including but not limited to videos, images or even another full page